### PR TITLE
Update pom.xml to use https:// URLs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@ xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/ma
     <repositories>
         <repository>
             <id>central</id>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <snapshots>
                 <enabled>false</enabled>
             </snapshots>


### PR DESCRIPTION
Otherwise, maven fails with:
501 HTTPS Required. 
Use https://repo1.maven.org/maven2/