### PR TITLE
fix BloomFilter's hash parameters

### DIFF
--- a/src/main/java/org/hoidla/stream/BloomFilter.java
+++ b/src/main/java/org/hoidla/stream/BloomFilter.java
@@ -41,7 +41,7 @@ public class BloomFilter {
 		
 		hashFamilySize = (int)Math.round(c *  bitVectorSize / maxSetSize) ;
 		filter = new BitSet(bitVectorSize);
-		hashFamily = new Hashing.MultiHashFamily(bitVectorSize, hashFamilySize);
+		hashFamily = new Hashing.MultiHashFamily(hashFamilySize, bitVectorSize);
 	}
 
 	/**


### PR DESCRIPTION
Hashing.MultiHashFamily takes (numHash, hashValueMax) in order, which is (hashFamilySize, bitVectorSize)